### PR TITLE
Add the ability to shift a Line/Span

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+target/
+Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lset"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Nathaniel McCallum <npmccallum@redhat.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/src/line.rs
+++ b/src/line.rs
@@ -18,6 +18,22 @@ pub struct Line<T> {
     pub end: T,
 }
 
+impl<T> Line<T> {
+    /// Create a new line
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// let line = lset::Line::new(5, 10);
+    /// assert_eq!(line.start, 5);
+    /// assert_eq!(line.end, 10);
+    /// ```
+    #[inline(always)]
+    pub const fn new(start: T, end: T) -> Self {
+        Self { start, end }
+    }
+}
+
 impl<T> From<Range<T>> for Line<T> {
     #[inline(always)]
     fn from(value: Range<T>) -> Self {

--- a/src/line.rs
+++ b/src/line.rs
@@ -34,6 +34,164 @@ impl<T> Line<T> {
     }
 }
 
+/// Grows the line by the size of the operand
+///
+/// # Example
+///
+/// ```
+/// let before = lset::Line::new(5, 10);
+/// let after = before + 5;
+/// assert_eq!(after.start, 5);
+/// assert_eq!(after.end, 15);
+/// ```
+impl<T: Add<T, Output = T>> Add<T> for Line<T> {
+    type Output = Self;
+
+    #[inline(always)]
+    fn add(self, rhs: T) -> Self::Output {
+        Self {
+            start: self.start,
+            end: self.end + rhs,
+        }
+    }
+}
+
+/// Grows the line by the size of the operand
+///
+/// # Example
+///
+/// ```
+/// let mut line = lset::Line::new(5, 10);
+/// line += 5;
+/// assert_eq!(line.start, 5);
+/// assert_eq!(line.end, 15);
+/// ```
+impl<T: AddAssign<T>> AddAssign<T> for Line<T> {
+    #[inline(always)]
+    fn add_assign(&mut self, rhs: T) {
+        self.end += rhs;
+    }
+}
+
+/// Shrinks the line by the size of the operand
+///
+/// # Example
+///
+/// ```
+/// let before = lset::Line::new(5, 10);
+/// let after = before - 5;
+/// assert_eq!(after.start, 5);
+/// assert_eq!(after.end, 5);
+/// ```
+impl<T: Sub<T, Output = T>> Sub<T> for Line<T> {
+    type Output = Self;
+
+    #[inline(always)]
+    fn sub(self, rhs: T) -> Self::Output {
+        Self {
+            start: self.start,
+            end: self.end - rhs,
+        }
+    }
+}
+
+/// Shrinks the line by the size of the operand
+///
+/// # Example
+///
+/// ```
+/// let mut line = lset::Line::new(5, 10);
+/// line -= 5;
+/// assert_eq!(line.start, 5);
+/// assert_eq!(line.end, 5);
+/// ```
+impl<T: SubAssign<T>> SubAssign<T> for Line<T> {
+    #[inline(always)]
+    fn sub_assign(&mut self, rhs: T) {
+        self.end -= rhs;
+    }
+}
+
+/// Shifts the line downwards without changing size
+///
+/// # Example
+///
+/// ```
+/// let before = lset::Line::new(5, 10);
+/// let after = before << 5;
+/// assert_eq!(after.start, 0);
+/// assert_eq!(after.end, 5);
+/// ```
+impl<T: Copy + Sub<T, Output = T>> Shl<T> for Line<T> {
+    type Output = Self;
+
+    #[inline(always)]
+    fn shl(self, rhs: T) -> Self::Output {
+        Self {
+            start: self.start - rhs,
+            end: self.end - rhs,
+        }
+    }
+}
+
+/// Shifts the line downwards without changing size
+///
+/// # Example
+///
+/// ```
+/// let mut line = lset::Line::new(5, 10);
+/// line <<= 5;
+/// assert_eq!(line.start, 0);
+/// assert_eq!(line.end, 5);
+/// ```
+impl<T: Copy + SubAssign<T>> ShlAssign<T> for Line<T> {
+    #[inline(always)]
+    fn shl_assign(&mut self, rhs: T) {
+        self.start -= rhs;
+        self.end -= rhs;
+    }
+}
+
+/// Shifts the line upwards without changing size
+///
+/// # Example
+///
+/// ```
+/// let before = lset::Line::new(5, 10);
+/// let after = before >> 5;
+/// assert_eq!(after.start, 10);
+/// assert_eq!(after.end, 15);
+/// ```
+impl<T: Copy + Add<T, Output = T>> Shr<T> for Line<T> {
+    type Output = Self;
+
+    #[inline(always)]
+    fn shr(self, rhs: T) -> Self::Output {
+        Self {
+            start: self.start + rhs,
+            end: self.end + rhs,
+        }
+    }
+}
+
+/// Shifts the line upwards without changing size
+///
+/// # Example
+///
+/// ```
+/// let mut line = lset::Line::new(5, 10);
+/// line >>= 5;
+/// assert_eq!(line.start, 10);
+/// assert_eq!(line.end, 15);
+/// ```
+impl<T: Copy + AddAssign<T>> ShrAssign<T> for Line<T> {
+    #[inline(always)]
+    fn shr_assign(&mut self, rhs: T) {
+        self.start += rhs;
+        self.end += rhs;
+    }
+}
+
 impl<T> From<Range<T>> for Line<T> {
     #[inline(always)]
     fn from(value: Range<T>) -> Self {

--- a/src/span.rs
+++ b/src/span.rs
@@ -18,6 +18,22 @@ pub struct Span<T, U = T> {
     pub count: U,
 }
 
+impl<T, U> Span<T, U> {
+    /// Create a new span
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// let span = lset::Span::new(5, 10);
+    /// assert_eq!(span.start, 5);
+    /// assert_eq!(span.count, 10);
+    /// ```
+    #[inline(always)]
+    pub const fn new(start: T, count: U) -> Self {
+        Self { start, count }
+    }
+}
+
 impl<T: Copy + Sub<T, Output = U>, U> From<Range<T>> for Span<T, U> {
     #[inline(always)]
     fn from(value: Range<T>) -> Self {

--- a/src/span.rs
+++ b/src/span.rs
@@ -34,6 +34,166 @@ impl<T, U> Span<T, U> {
     }
 }
 
+/// Grows the line by the size of the operand
+///
+/// # Example
+///
+/// ```
+/// let before = lset::Span::new(5, 10);
+/// let after = before + 5;
+/// assert_eq!(after.start, 5);
+/// assert_eq!(after.count, 15);
+/// ```
+impl<T: Add<T, Output = T>> Add<T> for Span<T> {
+    type Output = Self;
+
+    #[inline(always)]
+    fn add(self, rhs: T) -> Self::Output {
+        Self {
+            start: self.start,
+            count: self.count + rhs,
+        }
+    }
+}
+
+/// Grows the line by the size of the operand
+///
+/// # Example
+///
+/// ```
+/// let mut span = lset::Span::new(5, 10);
+/// span += 5;
+/// assert_eq!(span.start, 5);
+/// assert_eq!(span.count, 15);
+/// ```
+impl<T: AddAssign<T>> AddAssign<T> for Span<T> {
+    #[inline(always)]
+    fn add_assign(&mut self, rhs: T) {
+        self.count += rhs;
+    }
+}
+
+/// Shrinks the line by the size of the operand
+///
+/// # Example
+///
+/// ```
+/// let before = lset::Span::new(5, 10);
+/// let after = before - 5;
+/// assert_eq!(after.start, 5);
+/// assert_eq!(after.count, 5);
+/// ```
+impl<T: Sub<T, Output = T>> Sub<T> for Span<T> {
+    type Output = Self;
+
+    #[inline(always)]
+    fn sub(self, rhs: T) -> Self::Output {
+        Self {
+            start: self.start,
+            count: self.count - rhs,
+        }
+    }
+}
+
+/// Shrinks the line by the size of the operand
+///
+/// # Example
+///
+/// ```
+/// let mut span = lset::Span::new(5, 10);
+/// span -= 5;
+/// assert_eq!(span.start, 5);
+/// assert_eq!(span.count, 5);
+/// ```
+impl<T: SubAssign<T>> SubAssign<T> for Span<T> {
+    #[inline(always)]
+    fn sub_assign(&mut self, rhs: T) {
+        self.count -= rhs;
+    }
+}
+
+/// Shifts the line downwards without changing size
+///
+/// # Example
+///
+/// ```
+/// let before = lset::Span::new(5, 10);
+/// let after = before << 5;
+/// assert_eq!(after.start, 0);
+/// assert_eq!(after.count, 10);
+/// ```
+impl<T: Copy + Sub<T, Output = T>> Shl<T> for Span<T> {
+    type Output = Self;
+
+    #[inline(always)]
+    #[allow(clippy::suspicious_arithmetic_impl)]
+    fn shl(self, rhs: T) -> Self::Output {
+        Self {
+            start: self.start - rhs,
+            count: self.count,
+        }
+    }
+}
+
+/// Shifts the line downwards without changing size
+///
+/// # Example
+///
+/// ```
+/// let mut span = lset::Span::new(5, 10);
+/// span <<= 5;
+/// assert_eq!(span.start, 0);
+/// assert_eq!(span.count, 10);
+/// ```
+impl<T: Copy + SubAssign<T>> ShlAssign<T> for Span<T> {
+    #[inline(always)]
+    #[allow(clippy::suspicious_op_assign_impl)]
+    fn shl_assign(&mut self, rhs: T) {
+        self.start -= rhs;
+    }
+}
+
+/// Shifts the line upwards without changing size
+///
+/// # Example
+///
+/// ```
+/// let before = lset::Span::new(5, 10);
+/// let after = before >> 5;
+/// assert_eq!(after.start, 10);
+/// assert_eq!(after.count, 10);
+/// ```
+impl<T: Copy + Add<T, Output = T>> Shr<T> for Span<T> {
+    type Output = Self;
+
+    #[inline(always)]
+    #[allow(clippy::suspicious_arithmetic_impl)]
+    fn shr(self, rhs: T) -> Self::Output {
+        Self {
+            start: self.start + rhs,
+            count: self.count,
+        }
+    }
+}
+
+/// Shifts the line upwards without changing size
+///
+/// # Example
+///
+/// ```
+/// let mut span = lset::Span::new(5, 10);
+/// span >>= 5;
+/// assert_eq!(span.start, 10);
+/// assert_eq!(span.count, 10);
+/// ```
+impl<T: Copy + AddAssign<T>> ShrAssign<T> for Span<T> {
+    #[inline(always)]
+    #[allow(clippy::suspicious_op_assign_impl)]
+    fn shr_assign(&mut self, rhs: T) {
+        self.start += rhs;
+    }
+}
+
 impl<T: Copy + Sub<T, Output = U>, U> From<Range<T>> for Span<T, U> {
     #[inline(always)]
     fn from(value: Range<T>) -> Self {


### PR DESCRIPTION
This implements the Add/Sub operators for both Line and Span using their
inner types. This means you can shift a Line or Span using simple
addition or subtraction.

Signed-off-by: Nathaniel McCallum <nathaniel@congru.us>